### PR TITLE
New Feature & Bug Fixes

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,10 +1,13 @@
 [
     { "keys": ["alt+up"],         "command": "inc_dec_value", "args": { "action": "inc_min" } },
     { "keys": ["alt+down"],       "command": "inc_dec_value", "args": { "action": "dec_min" } },
+    { "keys": ["alt+insert"],     "command": "inc_dec_value", "args": { "action": "ins_min" } },
 
     { "keys": ["super+up"],       "command": "inc_dec_value", "args": { "action": "inc_max" } },
     { "keys": ["super+down"],     "command": "inc_dec_value", "args": { "action": "dec_max" } },
+    { "keys": ["super+insert"],   "command": "inc_dec_value", "args": { "action": "ins_max" } },
 
     { "keys": ["super+alt+up"],   "command": "inc_dec_value", "args": { "action": "inc_all" } },
-    { "keys": ["super+alt+down"], "command": "inc_dec_value", "args": { "action": "dec_all" } }
+    { "keys": ["super+alt+down"], "command": "inc_dec_value", "args": { "action": "dec_all" } },
+    { "keys": ["super+alt+insert"],"command":"inc_dec_value", "args": { "action": "ins_all" } }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,10 +1,13 @@
 [
   { "keys": ["alt+up"],              "command": "inc_dec_value", "args": { "action": "inc_min" } },
   { "keys": ["alt+down"],            "command": "inc_dec_value", "args": { "action": "dec_min" } },
+  { "keys": ["alt+insert"],          "command": "inc_dec_value", "args": { "action": "ins_min" } },
 
   { "keys": ["alt+super+up"],        "command": "inc_dec_value", "args": { "action": "inc_max" } },
   { "keys": ["alt+super+down"],      "command": "inc_dec_value", "args": { "action": "dec_max" } },
+  { "keys": ["alt+super+insert"],    "command": "inc_dec_value", "args": { "action": "ins_max" } },
 
   { "keys": ["super+alt+ctrl+up"],   "command": "inc_dec_value", "args": { "action": "inc_all" } },
-  { "keys": ["super+alt+ctrl+down"], "command": "inc_dec_value", "args": { "action": "dec_all" } }
+  { "keys": ["super+alt+ctrl+down"], "command": "inc_dec_value", "args": { "action": "dec_all" } },
+  { "keys": ["super+alt+ctrl+insert"],"command":"inc_dec_value", "args": { "action": "ins_all" } }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,10 +1,13 @@
 [
     { "keys": ["alt+up"],         "command": "inc_dec_value", "args": { "action": "inc_min" } },
     { "keys": ["alt+down"],       "command": "inc_dec_value", "args": { "action": "dec_min" } },
+    { "keys": ["alt+insert"],     "command": "inc_dec_value", "args": { "action": "ins_min" } },
 
     { "keys": ["super+alt+up"],   "command": "inc_dec_value", "args": { "action": "inc_max" } },
     { "keys": ["super+alt+down"], "command": "inc_dec_value", "args": { "action": "dec_max" } },
+    { "keys": ["super+alt+insert"],"command":"inc_dec_value", "args": { "action": "ins_max" } },
 
     { "keys": ["super+ctrl+up"],  "command": "inc_dec_value", "args": { "action": "inc_all" } },
-    { "keys": ["super+ctrl+down"],"command": "inc_dec_value", "args": { "action": "dec_all" } }
+    { "keys": ["super+ctrl+down"],"command": "inc_dec_value", "args": { "action": "dec_all" } },
+    { "keys": ["super+ctrl+insert"],"command":"inc_dec_value","args": { "action": "ins_all" } }
 ]

--- a/inc_dec_value.py
+++ b/inc_dec_value.py
@@ -57,8 +57,9 @@ class IncDecValueCommand(sublime_plugin.TextCommand):
                     self.apply_enums()              or
                     self.apply_string()
                 )
-                if self.settings.get("autosave"):
-                    self.view.run_command('save')
+
+        if self.settings.get("autosave"):
+            self.view.run_command('save')
 
 
     def load_settings(self):

--- a/inc_dec_value.py
+++ b/inc_dec_value.py
@@ -299,7 +299,7 @@ class IncDecValueCommand(sublime_plugin.TextCommand):
 
             tmp_reg = sublime.Region(prev['pos'], self.word_reg.end())
             word = self.get_word(tmp_reg)
-            match = re.match('(-*\d+\.(\d+))([a-zA-Z%]+)?$', word)
+            match = re.match('(-*\d*\.(\d+))([a-zA-Z%]+)?$', word)
 
             if match:
                 float_len = len(match.group(2))

--- a/inc_dec_value.sublime-settings
+++ b/inc_dec_value.sublime-settings
@@ -4,12 +4,15 @@
 
 ,   "action_inc_min":    1  // default:   1,  key: Alt + Up
 ,   "action_dec_min":   -1  // default:  -1,  key: Alt + Down
+,   "action_ins_min":    1  // default:   1,  key: Alt + Insert
 
 ,   "action_inc_max":   10  // default:  10,  key: Super + Up
 ,   "action_dec_max":  -10  // default: -10,  key: Super + Down
+,   "action_ins_max":   10  // default:  10,  key: Super + Insert
 
 ,   "action_inc_all":  100  // default:  10,  key: Super + Alt + Up
 ,   "action_dec_all": -100  // default: -10,  key: Super + Alt + Down
+,   "action_ins_all":  100  // default:  100,  key: Super + Alt + Insert
 
 
 ,   "enums": [

--- a/inc_dec_value.sublime-settings
+++ b/inc_dec_value.sublime-settings
@@ -10,8 +10,8 @@
 ,   "action_dec_max":  -10  // default: -10,  key: Super + Down
 ,   "action_ins_max":   10  // default:  10,  key: Super + Insert
 
-,   "action_inc_all":  100  // default:  10,  key: Super + Alt + Up
-,   "action_dec_all": -100  // default: -10,  key: Super + Alt + Down
+,   "action_inc_all":  100  // default:  100,  key: Super + Alt + Up
+,   "action_dec_all": -100  // default: -100,  key: Super + Alt + Down
 ,   "action_ins_all":  100  // default:  100,  key: Super + Alt + Insert
 
 


### PR DESCRIPTION
I added the ability to insert incrementing numbers at the selections. It takes advantage of the delta values to insert numbers incrementing by 1, 10, 100 (or whatever the user's settings are).
Note: I kept the same shortcut formats, but with the Insert key. I'm not sure what this maps to on OSX.

I also fixed a typo in the settings comments and stopped it from auto-saving on every selection iteration. It will only save it once, after the loop.

Fixed rmaksim/Sublime-Text-2-Inc-Dec-Value#36 by not requiring a leading digit in the float checking regex.
